### PR TITLE
Fix sha1 hash

### DIFF
--- a/server/image.go
+++ b/server/image.go
@@ -49,7 +49,7 @@ func NewImageFromSrcUrl(srcUrl string) *Image {
 
 func sha1Hash(in string) string {
 	hasher := sha1.New()
-	fmt.Fprintf(hasher, in)
+	fmt.Fprint(hasher, in)
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 


### PR DESCRIPTION
I found an interesting bug in generating hashes.

Before this fix - `Fprintf()` expects more arguments and thus generates some mess from escaped URL:

```
https://imgry.pressly.com/529dfe4b6461733d2e280000//fetch?url=http%!A(MISSING)%!F(MISSING)%!F(MISSING)icdn2.digitaltrends.com%!F(MISSING)image%!F(MISSING)amazon-prime-drone-2-600x315-c.jpg&size=640x416&op=cover

6a76e0438c66a58472bd603fecbb585b72d2d1c6
```

After this fix:

```
https://imgry.pressly.com/529dfe4b6461733d2e280000//fetch?url=http%3A%2F%2Ficdn2.digitaltrends.com%2Fimage%2Famazon-prime-drone-2-600x315-c.jpg&size=640x416&op=cover

1683457f5bf48189b498bb4af55bf1f97df7bbad
```
