### PR TITLE
Use different resize filters for shrinking and enlarging

### DIFF
--- a/imagick/imagick.go
+++ b/imagick/imagick.go
@@ -297,8 +297,17 @@ func (i *Image) sizeFrames(sz *imgry.Sizing) error {
 		// Resize the image
 		resizeRect, cropBox, cropOrigin := sz.CalcResizeRect(srcSize)
 		if resizeRect != nil && !resizeRect.Equal(imgry.ZeroRect) {
+			var resizeFilter imagick.FilterType
 
-			err := i.mw.ResizeImage(uint(resizeRect.Width), uint(resizeRect.Height), imagick.FILTER_LANCZOS)
+			if resizeRect.Width > sz.Size.Width {
+				// use Mitchell-Netravali cubic filter when enlarging
+				resizeFilter = imagick.FILTER_MITCHELL
+			} else {
+				// use sharp variant of 3-lobed cylindrical lanczos when shrinking
+				resizeFilter = imagick.FILTER_LANCZOS_SHARP
+			}
+
+			err := i.mw.ResizeImage(uint(resizeRect.Width), uint(resizeRect.Height), resizeFilter)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Basic Lanczos is a bit soft for both shrinking and enlarging.
Sharp variant fares significanlty better when shrinking, but has even more ringing than basic, which is especially visibie when enlarging high-contrast images.
To not have to deal with the problem use Mitchell-Netravali filter for enlarging instead as it is a reasonable compromise between artifacting and sharpness with little distortion.

Possible future improvements: factor bits per color and contrast when selecting resize filter